### PR TITLE
쇼핑몰 리스트 필터 조회

### DIFF
--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/CustomStoreRepository.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/CustomStoreRepository.kt
@@ -1,9 +1,12 @@
 package com.jansparta.hvt_project.domain.store.repository
 
+import com.jansparta.hvt_project.domain.store.model.Store
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 
 interface CustomStoreRepository {
     //QueryDSL 작성
+
+    fun findByRatingAndStatus(rating:Int?, status: String?) : List<Store>
 
 }

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/StoreRepositoryImpl.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/StoreRepositoryImpl.kt
@@ -1,7 +1,9 @@
 package com.jansparta.hvt_project.domain.store.repository
 
 import com.jansparta.hvt_project.domain.store.model.QStore
+import com.jansparta.hvt_project.domain.store.model.Store
 import com.jansparta.hvt_project.infra.querydsl.QueryDslSupport
+import com.querydsl.core.BooleanBuilder
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -10,4 +12,15 @@ class StoreRepositoryImpl : CustomStoreRepository, QueryDslSupport() {
 
     private val store = QStore.store
 
+    override fun findByRatingAndStatus(rating: Int?, status: String?): List<Store> {
+        val whereClause = BooleanBuilder()
+
+        rating?.let { whereClause.and(store.totRatingPoint.eq(it)) }
+        status?.let { whereClause.and(store.statNm.eq(it)) }
+
+        return queryFactory.selectFrom(store)
+            .where(whereClause)
+            .orderBy(store.regDate.desc())
+            .fetch()
+    }
 }

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/StoreRepositoryImpl.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/StoreRepositoryImpl.kt
@@ -21,6 +21,7 @@ class StoreRepositoryImpl : CustomStoreRepository, QueryDslSupport() {
         return queryFactory.selectFrom(store)
             .where(whereClause)
             .orderBy(store.regDate.desc())
+            .limit(10)
             .fetch()
     }
 }


### PR DESCRIPTION
‘전체평가’ 필터 조회와 ‘업소상태’ 필터 조회(2개 필터 동시 적용, 각각 1개씩 적용)
‘모니터링날짜’의 내림차순 정렬 후 상위 10개 리스트 보여주기