### PR TITLE
리스트조회 API 2개

### DIFF
--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/controller/StoreController.kt
@@ -4,14 +4,9 @@ import com.jansparta.hvt_project.domain.store.dto.CreateStoreRequest
 import com.jansparta.hvt_project.domain.store.dto.StoreResponse
 import com.jansparta.hvt_project.domain.store.dto.UpdateStoreRequest
 import com.jansparta.hvt_project.domain.store.service.StoreService
+import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.PutMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 @RequestMapping("/stores")
@@ -54,9 +49,13 @@ class StoreController (
     }
 
     @GetMapping("/filtered")
-    fun getFilteredStores()
-    {
-        TODO()
+    fun getFilteredStores(
+        @RequestParam(value = "rating", required = false) rating:Int?,
+        @RequestParam(value = "status", required = false) status:String?
+    ) : ResponseEntity<List<StoreResponse>> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(storeService.getFilteredStores(rating, status))
     }
 
     @GetMapping("/filtered/simple")

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/controller/StoreController.kt
@@ -4,6 +4,9 @@ import com.jansparta.hvt_project.domain.store.dto.CreateStoreRequest
 import com.jansparta.hvt_project.domain.store.dto.StoreResponse
 import com.jansparta.hvt_project.domain.store.dto.UpdateStoreRequest
 import com.jansparta.hvt_project.domain.store.service.StoreService
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
+import org.springframework.data.web.PageableDefault
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.*
@@ -49,14 +52,27 @@ class StoreController (
     }
 
     @GetMapping("/filtered")
-    fun getFilteredStores(
+    fun getFilteredStoreList(
         @RequestParam(value = "rating", required = false) rating:Int?,
         @RequestParam(value = "status", required = false) status:String?
     ) : ResponseEntity<List<StoreResponse>> {
         return ResponseEntity
             .status(HttpStatus.OK)
-            .body(storeService.getFilteredStores(rating, status))
+            .body(storeService.getFilteredStoreList(rating, status))
     }
+
+    @GetMapping("/pagenated")
+    fun getFilteredStorePage(
+        @PageableDefault(size = 10) pageable: Pageable,
+        @RequestParam(value = "cursorId", required = false) cursorId: Long?,
+        @RequestParam(value = "rating", required = false) rating:Int?,
+        @RequestParam(value = "status", required = false) status:String?
+    ) : ResponseEntity<Page<StoreResponse>> {
+        return ResponseEntity
+            .status(HttpStatus.OK)
+            .body(storeService.getFilteredStorePage(pageable, cursorId, rating, status))
+    }
+
 
     @GetMapping("/filtered/simple")
     fun getFilteredSimpleStore()

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/CustomStoreRepository.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/CustomStoreRepository.kt
@@ -9,4 +9,5 @@ interface CustomStoreRepository {
 
     fun findByRatingAndStatus(rating:Int?, status: String?) : List<Store>
 
+    fun findByPageableAndFilter(pageable: Pageable, cursorId: Long?, rating:Int?, status: String?): Page<Store>
 }

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/StoreRepositoryImpl.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/StoreRepositoryImpl.kt
@@ -4,6 +4,9 @@ import com.jansparta.hvt_project.domain.store.model.QStore
 import com.jansparta.hvt_project.domain.store.model.Store
 import com.jansparta.hvt_project.infra.querydsl.QueryDslSupport
 import com.querydsl.core.BooleanBuilder
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.PageImpl
+import org.springframework.data.domain.Pageable
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -23,5 +26,31 @@ class StoreRepositoryImpl : CustomStoreRepository, QueryDslSupport() {
             .orderBy(store.regDate.desc())
             .limit(10)
             .fetch()
+    }
+
+    override fun findByPageableAndFilter(pageable: Pageable, cursorId: Long?, rating: Int?, status: String?): Page<Store> {
+        val whereClause = BooleanBuilder()
+
+        rating?.let { whereClause.and(store.totRatingPoint.eq(it)) }
+        status?.let { whereClause.and(store.statNm.eq(it)) }
+
+        val totalCount = queryFactory.select(store.count()).from(store).where(whereClause).fetchOne() ?: 0L
+
+        val query = queryFactory.selectFrom(store)
+            .limit(pageable.pageSize.toLong())
+
+        if (pageable.sort.isSorted) {
+            if(pageable.sort.first()?.property == "desc") query.orderBy(store.id.desc())
+            else query.orderBy(store.id.asc())
+        } else {
+            query.orderBy(store.id.asc())
+        }
+//
+//        cursorId?.let { whereClause.and(store.id.gt(it)) } // asc
+//        cursorId?.let { whereClause.and(store.id.lt(it)) } // desc
+//        query.where(whereClause)
+
+        val contents = query.fetch()
+        return PageImpl(contents, pageable, totalCount)
     }
 }

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/StoreRepositoryImpl.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/StoreRepositoryImpl.kt
@@ -33,24 +33,16 @@ class StoreRepositoryImpl : CustomStoreRepository, QueryDslSupport() {
 
         rating?.let { whereClause.and(store.totRatingPoint.eq(it)) }
         status?.let { whereClause.and(store.statNm.eq(it)) }
+        cursorId?.let { whereClause.and(store.id.lt(it)) } // desc
 
         val totalCount = queryFactory.select(store.count()).from(store).where(whereClause).fetchOne() ?: 0L
 
-        val query = queryFactory.selectFrom(store)
+        val contents = queryFactory.selectFrom(store)
+            .where(whereClause)
             .limit(pageable.pageSize.toLong())
+            .orderBy(store.id.desc())
+            .fetch()
 
-        if (pageable.sort.isSorted) {
-            if(pageable.sort.first()?.property == "desc") query.orderBy(store.id.desc())
-            else query.orderBy(store.id.asc())
-        } else {
-            query.orderBy(store.id.asc())
-        }
-//
-//        cursorId?.let { whereClause.and(store.id.gt(it)) } // asc
-//        cursorId?.let { whereClause.and(store.id.lt(it)) } // desc
-//        query.where(whereClause)
-
-        val contents = query.fetch()
         return PageImpl(contents, pageable, totalCount)
     }
 }

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/service/StoreService.kt
@@ -17,7 +17,7 @@ interface StoreService {
 
     fun getAllSimpleStores()
 
-    fun getFilteredStores()
+    fun getFilteredStores(rating: Int?, status: String?) : List<StoreResponse>
 
     fun getFilteredSimpleStore()
 

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/service/StoreService.kt
@@ -3,6 +3,9 @@ package com.jansparta.hvt_project.domain.store.service
 import com.jansparta.hvt_project.domain.store.dto.CreateStoreRequest
 import com.jansparta.hvt_project.domain.store.dto.StoreResponse
 import com.jansparta.hvt_project.domain.store.dto.UpdateStoreRequest
+import com.jansparta.hvt_project.domain.store.model.Store
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 
 interface StoreService {
@@ -17,7 +20,9 @@ interface StoreService {
 
     fun getAllSimpleStores()
 
-    fun getFilteredStores(rating: Int?, status: String?) : List<StoreResponse>
+    fun getFilteredStoreList(rating: Int?, status: String?) : List<StoreResponse>
+
+    fun getFilteredStorePage(pageable: Pageable, cursorId: Long?, rating: Int?, status: String?): Page<StoreResponse>
 
     fun getFilteredSimpleStore()
 

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/service/StoreServiceImpl.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/service/StoreServiceImpl.kt
@@ -5,6 +5,8 @@ import com.jansparta.hvt_project.domain.store.dto.StoreResponse
 import com.jansparta.hvt_project.domain.store.dto.UpdateStoreRequest
 import com.jansparta.hvt_project.domain.store.dto.toResponse
 import com.jansparta.hvt_project.domain.store.repository.StoreRepository
+import org.springframework.data.domain.Page
+import org.springframework.data.domain.Pageable
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
 
@@ -34,8 +36,17 @@ class StoreServiceImpl(
         TODO("Not yet implemented")
     }
 
-    override fun getFilteredStores(rating: Int?, status: String?): List<StoreResponse> {
+    override fun getFilteredStoreList(rating: Int?, status: String?): List<StoreResponse> {
         return storeRepository.findByRatingAndStatus(rating, status).map { it.toResponse() }
+    }
+
+    override fun getFilteredStorePage(
+        pageable: Pageable,
+        cursorId: Long?,
+        rating: Int?,
+        status: String?
+    ): Page<StoreResponse> {
+        return storeRepository.findByPageableAndFilter(pageable, cursorId, rating, status).map { it.toResponse() }
     }
 
     override fun getFilteredSimpleStore() {

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/service/StoreServiceImpl.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/service/StoreServiceImpl.kt
@@ -3,6 +3,7 @@ package com.jansparta.hvt_project.domain.store.service
 import com.jansparta.hvt_project.domain.store.dto.CreateStoreRequest
 import com.jansparta.hvt_project.domain.store.dto.StoreResponse
 import com.jansparta.hvt_project.domain.store.dto.UpdateStoreRequest
+import com.jansparta.hvt_project.domain.store.dto.toResponse
 import com.jansparta.hvt_project.domain.store.repository.StoreRepository
 import org.springframework.http.ResponseEntity
 import org.springframework.stereotype.Service
@@ -33,8 +34,8 @@ class StoreServiceImpl(
         TODO("Not yet implemented")
     }
 
-    override fun getFilteredStores() {
-        TODO("Not yet implemented")
+    override fun getFilteredStores(rating: Int?, status: String?): List<StoreResponse> {
+        return storeRepository.findByRatingAndStatus(rating, status).map { it.toResponse() }
     }
 
     override fun getFilteredSimpleStore() {

--- a/src/main/kotlin/com/jansparta/hvt_project/infra/swagger/SwaggerConfig.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/infra/swagger/SwaggerConfig.kt
@@ -1,0 +1,38 @@
+package com.jansparta.hvt_project.infra.swagger
+
+import io.swagger.v3.oas.models.Components
+import io.swagger.v3.oas.models.OpenAPI
+import io.swagger.v3.oas.models.info.Info
+import io.swagger.v3.oas.models.security.SecurityRequirement
+import io.swagger.v3.oas.models.security.SecurityScheme
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class SwaggerConfig {
+
+    @Bean
+    fun openAPI(): OpenAPI {
+        return OpenAPI()
+            .addSecurityItem(
+                SecurityRequirement().addList("Bearer Authentication")
+            )
+            .components(
+                Components().addSecuritySchemes(
+                    "Bearer Authentication",
+                    SecurityScheme()
+                        .type(SecurityScheme.Type.HTTP)
+                        .scheme("Bearer")
+                        .bearerFormat("JWT")
+                        .`in`(SecurityScheme.In.HEADER)
+                        .name("Authorization")
+                )
+            )
+            .info(
+                Info()
+                    .title("HVT Project API")
+                    .description("HVT Project API schema")
+                    .version("1.0.0")
+            )
+    }
+}


### PR DESCRIPTION
1. 필터 리스트조회 API

- 필터 : 미입력, 하나만 입력, 모두 입력, 잘못된 내용 입력
- ‘모니터링날짜’의 내림차순 정렬 후 상위 10개 리스트 반환
<br>

2. 페이징&필터 리스트조회 API

- 커서 페이징 : offset(크기) 대신 cursor(식별자 값)으로 위치를 지정하여 페이징하는 방식  (cursorId를 RequestParam으로 받음)
- 필터 : 미입력, 하나만 입력, 모두 입력, 잘못된 내용 입력
- ‘id’의 내림차순 정렬 후 10개씩 잘라서 반환 (=최신순)