### PR TITLE
Feat/news cache 2 // 단건 조회/검색 분리

### DIFF
--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/controller/StoreController.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/controller/StoreController.kt
@@ -85,9 +85,7 @@ class StoreController (
             .body(storeService.getFilteredSimpleStorePage(pageable, cursorId, rating, status))
     }
 
-    @CacheTimer
     @GetMapping() // 업체 리스트 전체 조회
-    // @Cacheable("storeListCache")
     fun <T> getStores(
         @PageableDefault( size = 10, sort = ["id"]) pageable: Pageable,
         toSimple : Boolean // Projection 적용 여부
@@ -97,15 +95,23 @@ class StoreController (
     }
 
     @CacheTimer
-    @GetMapping("/search") // 업체 단건 조회
-    fun getStoreBy(
+    @GetMapping("/{id}") // 업체 단건 조회
+    fun getStoreById(
+        @PathVariable id : Long,
+    ) : ResponseEntity<StoreResponse>
+    {
+        return ResponseEntity.status(HttpStatus.OK).body(storeService.getStoreById(id))
+    }
+    @CacheTimer
+    @GetMapping("/search") // 업체 검색. 전문 검색 엔진 필요 (ElasticSearch 등)
+    fun searchStoresBy(
         @RequestParam(value = "Id(아이디)", required = false) id : Long?,
         @RequestParam(value = "Company(상호명)", required = false) company : String?,
         @RequestParam(value = "shopName(쇼핑몰명)", required = false) shopName : String?,
         @RequestParam(value = "tel(전화번호)", required = false) tel : String?,
-    ) : ResponseEntity<StoreResponse>
+    ) : ResponseEntity<List<StoreResponse>>
     {
-        return ResponseEntity.status(HttpStatus.OK).body(storeService.getStoreBy(id,company,shopName,tel))
+        return ResponseEntity.status(HttpStatus.OK).body(storeService.searchStoresBy(id,company,shopName,tel))
     }
 
     @CacheTimer

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/CustomStoreRepository.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/CustomStoreRepository.kt
@@ -13,8 +13,9 @@ interface CustomStoreRepository {
     fun getNewStores(size : Long) : List<Store>
     fun <T> getStores(pageable: Pageable, type: Class<T>): Page<T>?
 
-    fun getStoreBy(id: Long?, company: String?, shopName: String?, tel: String?) : Store
+    fun getStoreBy(id: Long) : Store
 
+    fun searchStoresBy(company: String?, shopName: String?, tel: String?) : List<Store>
 
     fun findByRatingAndStatus(rating:Int?, status: String?) : List<Store>
 

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/StoreRepositoryImpl.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/repository/StoreRepositoryImpl.kt
@@ -65,20 +65,28 @@ class StoreRepositoryImpl : CustomStoreRepository, QueryDslSupport() {
         return PageImpl(contents, pageable, totalCounts)
     }
 
-    override fun getStoreBy(id: Long?, company: String?, shopName: String?, tel: String?): Store {
+    override fun getStoreBy(id: Long): Store {
 
         var whereClause = BooleanBuilder()
-        id?.let { whereClause.and(store.id.eq(id)) }
-        company?.let { whereClause.and(store.company.eq(company)) }
-        shopName?.let { whereClause.and(store.shopName.eq(shopName)) }
-        tel?.let { whereClause.and(store.tel.eq(tel)) }
-
-
+        whereClause.and(store.id.eq(id))
 
         return queryFactory
             .selectFrom(store)
             .where(whereClause)
-            .fetchOne() ?: throw NotFoundException()
+            .limit(1)
+            .fetchOne()?: throw NotFoundException()
+    }
+    override fun searchStoresBy(company: String?, shopName: String?, tel: String?): List<Store> {
+
+        val whereClause = BooleanBuilder()
+        company?.let { whereClause.and(store.company.eq(company)) }
+        shopName?.let { whereClause.and(store.shopName.like("%$shopName%")) } // 응답시간 초과. 전문검색엔진 필요
+        tel?.let { whereClause.and(store.tel.like("%$tel%")) }
+
+        return queryFactory
+            .selectFrom(store)
+            .where(whereClause)
+            .fetch() ?: emptyList()
     }
 
     override fun findByRatingAndStatus(rating: Int?, status: String?): List<Store> {

--- a/src/main/kotlin/com/jansparta/hvt_project/domain/store/service/StoreService.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/domain/store/service/StoreService.kt
@@ -17,7 +17,9 @@ interface StoreService {
     fun getFilteredStorePage(pageable: Pageable, cursorId: Long?, rating: Int?, status: String?): Page<StoreResponse>
     fun getFilteredSimpleStorePage(pageable: Pageable, cursorId: Long?, rating: Int?, status: String?): Page<SimpleStoreResponse>
     fun <T> getStoreList( pageable: Pageable, toSimple:Boolean) : Page<T>
-    fun getStoreBy( id : Long? , company : String? , shopName : String? , tel : String? ) : StoreResponse
+
+    fun getStoreById( id : Long) : StoreResponse
+    fun searchStoresBy( id : Long? , company : String? , shopName : String? , tel : String? ) : List<StoreResponse>
     fun getNewStores( size : Long ) : List<StoreResponse>
     fun updateStore( request : UpdateStoreRequest , id : Long) : StoreResponse
     fun deleteStore( id:Long )

--- a/src/main/kotlin/com/jansparta/hvt_project/infra/Redis/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/jansparta/hvt_project/infra/Redis/RedisCacheConfig.kt
@@ -25,21 +25,21 @@ import java.time.Duration
 class RedisCacheConfig {
 
     // jackson LocalDateTime mapper
-    @Bean
-    fun objectMapper(): ObjectMapper {
-        val mapper = ObjectMapper()
-        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) // timestamp 형식 안따르도록 설정
-//        mapper.registerModules(JavaTimeModule(), Jdk8Module()) // LocalDateTime 매핑을 위해 모듈 활성화
-        mapper.registerModule(ParameterNamesModule());
-        return mapper
-    }
+//    @Bean
+//    fun objectMapper(): ObjectMapper {
+//        val mapper = ObjectMapper()
+//        mapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS) // timestamp 형식 안따르도록 설정
+////        mapper.registerModules(JavaTimeModule(), Jdk8Module()) // LocalDateTime 매핑을 위해 모듈 활성화
+//        mapper.registerModule(ParameterNamesModule());
+//        return mapper
+//    }
 
     @Bean
     fun defaultCacheManager(connectionFactory: RedisConnectionFactory): CacheManager {
         val objectMapper = ObjectMapper().registerModules(kotlinModule()).activateDefaultTyping(
             BasicPolymorphicTypeValidator.builder().allowIfBaseType(Any::class.java).build(),
             ObjectMapper.DefaultTyping.EVERYTHING
-        ).registerModules(JavaTimeModule(), Jdk8Module())
+        ).registerModules(JavaTimeModule(), Jdk8Module()) // LocalDateTime 모듈 적용
 
 
         val redisCacheConfiguration: RedisCacheConfiguration = RedisCacheConfiguration.defaultCacheConfig()


### PR DESCRIPTION

- getStoreByID : ID 로 조회하기 (cache적용)
- searchStoresBy : ID, 상호명, 쇼핑몰명, 전화번호로 검색( ID 검색시 cache 적용 )
- 검색의 경우 데이터가 너무 많아 응답초과 되어버리는 현상 발생. 추후 전문검색엔진 연구 후 적용 필요